### PR TITLE
Session-level skin override

### DIFF
--- a/Code/SkinModHelperInterop.cs
+++ b/Code/SkinModHelperInterop.cs
@@ -6,5 +6,13 @@ namespace Celeste.Mod.SkinModHelper {
         internal static void Load() {
             typeof(SkinModHelperInterop).ModInterop();
         }
+
+        public static void ApplySkinGlobal(string newSkin) {
+            SkinModHelperModule.UpdateSkin(newSkin);
+        }
+
+        public static void ApplySkinSession(string newSkin) {
+            SkinModHelperModule.SetSessionSkin(newSkin);
+        }
     }
 }

--- a/Code/SkinModHelperSession.cs
+++ b/Code/SkinModHelperSession.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.SkinModHelper {
+    public class SkinModHelperSession : EverestModuleSession {
+        public string SkinOverride { get; set; }
+    }
+}

--- a/Code/SkinSwapTrigger.cs
+++ b/Code/SkinSwapTrigger.cs
@@ -13,7 +13,7 @@ namespace Celeste.Mod.SkinModHelper {
             skinId = data.Attr("skinId", SkinModHelperModule.DEFAULT);
             revertOnLeave = data.Bool("revertOnLeave", false);
 
-            oldSkinId = SkinModHelperModule.Settings.SelectedSkinMod;
+            oldSkinId = SkinModHelperModule.Session.SkinOverride;
         }
 
         public override void OnEnter(Player player) {
@@ -24,13 +24,13 @@ namespace Celeste.Mod.SkinModHelper {
             }
 
             oldSkinId = SkinModHelperModule.Settings.SelectedSkinMod;
-            SkinModHelperModule.UpdateSkin(skinId);
+            SkinModHelperModule.SetSessionSkin(skinId);
         }
 
         public override void OnLeave(Player player) {
             base.OnLeave(player);
             if (revertOnLeave) {
-                SkinModHelperModule.UpdateSkin(oldSkinId);
+                SkinModHelperModule.SetSessionSkin(oldSkinId);
             }
         }
     }


### PR DESCRIPTION
- Add a skin property to the (newly created) SkinModHelperSession
- Add a property on the module to get the currently active skin, respecting the session -> setting -> default hierarchy and validating that the skin exists
- Update appropriate places in code to use the new property rather than looking directly to settings
- Triggers now apply skins at the session level so they don't persist to other maps
- Add function to ModInterop to set the skin at setting level
- Add function to ModInterop to set the skin at session level